### PR TITLE
Improve reservation handling

### DIFF
--- a/src/canchamanager/grupo12/upn/data/DataManager.java
+++ b/src/canchamanager/grupo12/upn/data/DataManager.java
@@ -8,6 +8,7 @@ import canchamanager.grupo12.upn.model.Cancha;
 import java.time.LocalDate;
 import java.time.LocalTime;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 
 /**
@@ -36,7 +37,7 @@ public class DataManager {
   * @return Una lista de objetos Cancha.
   */
  public static List<Cancha> getCanchas() {
-     return canchas;
+     return Collections.unmodifiableList(canchas);
  }
 
  /**
@@ -52,31 +53,104 @@ public class DataManager {
   * @return Una lista de objetos Reserva.
   */
  public static List<Reserva> getReservas() {
-     return reservas;
+     return Collections.unmodifiableList(reservas);
  }
 
- /**
-  * Agrega una nueva reserva a la lista.
-  * @param reserva La instancia de Reserva a agregar.
-  */
- public static void addReserva(Reserva reserva) {
-     reservas.add(reserva);
- }
+    /**
+     * Agrega una nueva reserva si no existe un cruce de horarios y la cancha
+     * está disponible en ese intervalo (RF05, RF06, RF18).
+     *
+     * @param reserva La instancia de Reserva a agregar.
+     * @return {@code true} si la reserva fue agregada correctamente,
+     *         {@code false} si hubo un conflicto de horarios o fuera del
+     *         horario permitido.
+     */
+    public static boolean addReserva(Reserva reserva) {
+        // Verificar que la reserva esté dentro del horario permitido de la cancha
+        if (!dentroDeHorario(reserva.getCancha(), reserva.getHoraInicio(), reserva.getHoraFin())) {
+            return false;
+        }
+
+        // Comprobar que no exista cruce de horarios con otras reservas
+        if (hayCruceDeHorario(reserva.getCancha(), reserva.getFecha(),
+                reserva.getHoraInicio(), reserva.getHoraFin(), null)) {
+            return false;
+        }
+
+        reservas.add(reserva);
+        return true;
+    }
 
  /**
   * Obtiene todas las reservas para una fecha específica.
   * @param fecha La fecha para la cual se desean obtener las reservas.
   * @return Una lista de objetos Reserva correspondientes a la fecha dada.
   */
- public static List<Reserva> getReservasPorDia(LocalDate fecha) {
-     List<Reserva> reservasDelDia = new ArrayList<>();
-     for (Reserva r : reservas) {
-         if (r.getFecha().isEqual(fecha)) {
-             reservasDelDia.add(r);
-         }
-     }
-     return reservasDelDia;
- }
+    public static List<Reserva> getReservasPorDia(LocalDate fecha) {
+        List<Reserva> reservasDelDia = new ArrayList<>();
+        for (Reserva r : reservas) {
+            if (r.getFecha().isEqual(fecha)) {
+                reservasDelDia.add(r);
+            }
+        }
+        return reservasDelDia;
+    }
+
+    /**
+     * Cancela una reserva existente. (RF08)
+     * @param reserva La reserva a eliminar.
+     */
+    public static void cancelarReserva(Reserva reserva) {
+        reservas.remove(reserva);
+    }
+
+    /**
+     * Marca una reserva como pagada. (RF11)
+     * @param reserva Reserva a actualizar.
+     */
+    public static void marcarReservaPagada(Reserva reserva) {
+        if (reservas.contains(reserva)) {
+            reserva.setPagada(true);
+        }
+    }
+
+    /**
+     * Edita una reserva existente cambiando cancha u horario si está disponible.
+     * (RF07)
+     *
+     * @param reserva        Reserva a modificar.
+     * @param nuevaCancha    Nueva cancha para la reserva.
+     * @param nuevaFecha     Nueva fecha.
+     * @param nuevaHoraInicio Nueva hora de inicio.
+     * @param nuevaHoraFin   Nueva hora de fin.
+     * @return {@code true} si la reserva se actualizó correctamente,
+     *         {@code false} si hubo conflicto de horarios o el horario está fuera
+     *         del rango permitido.
+     */
+    public static boolean editarReserva(Reserva reserva, Cancha nuevaCancha,
+            LocalDate nuevaFecha, LocalTime nuevaHoraInicio, LocalTime nuevaHoraFin) {
+
+        if (!reservas.contains(reserva)) {
+            return false;
+        }
+
+        // Validar horario permitido
+        if (!dentroDeHorario(nuevaCancha, nuevaHoraInicio, nuevaHoraFin)) {
+            return false;
+        }
+
+        // Verificar cruce excluyendo la propia reserva
+        if (hayCruceDeHorario(nuevaCancha, nuevaFecha, nuevaHoraInicio, nuevaHoraFin, reserva)) {
+            return false;
+        }
+
+        reserva.setCancha(nuevaCancha);
+        reserva.setFecha(nuevaFecha);
+        reserva.setHoraInicio(nuevaHoraInicio);
+        reserva.setHoraFin(nuevaHoraFin);
+
+        return true;
+    }
 
  /**
   * Verifica si hay un cruce de horarios para una cancha y fecha dadas.
@@ -89,11 +163,11 @@ public class DataManager {
   * Si es una nueva reserva, este parámetro debe ser `null`.
   * @return `true` si hay un cruce de horario, `false` en caso contrario.
   */
- public static boolean hayCruceDeHorario(Cancha cancha, LocalDate fecha, LocalTime nuevaHoraInicio, LocalTime nuevaHoraFin, Reserva reservaAExcluir) {
-     for (Reserva r : reservas) {
-         // Excluir la propia reserva si estamos editando (para que no se detecte un cruce consigo misma)
-         if (r == reservaAExcluir) {
-             continue;
+    public static boolean hayCruceDeHorario(Cancha cancha, LocalDate fecha, LocalTime nuevaHoraInicio, LocalTime nuevaHoraFin, Reserva reservaAExcluir) {
+        for (Reserva r : reservas) {
+            // Excluir la propia reserva si estamos editando (para que no se detecte un cruce consigo misma)
+            if (r == reservaAExcluir) {
+                continue;
          }
          // Comprobar si la reserva actual es para la misma cancha y la misma fecha
          if (r.getCancha().equals(cancha) && r.getFecha().isEqual(fecha)) {
@@ -103,8 +177,20 @@ public class DataManager {
              if (nuevaHoraInicio.isBefore(r.getHoraFin()) && nuevaHoraFin.isAfter(r.getHoraInicio())) {
                  return true; // Hay cruce
              }
-         }
-     }
-     return false; // No hay cruce
- }
+        }
+    }
+    return false; // No hay cruce
+}
+
+    // Verifica que un intervalo de horas esté dentro del horario disponible de la cancha
+    private static boolean dentroDeHorario(Cancha cancha, LocalTime inicio, LocalTime fin) {
+        String horario = cancha.getHorarioDisponible();
+        String[] partes = horario.split("-");
+        if (partes.length != 2) {
+            return false; // formato incorrecto
+        }
+        LocalTime inicioCancha = LocalTime.parse(partes[0]);
+        LocalTime finCancha = LocalTime.parse(partes[1]);
+        return !inicio.isBefore(inicioCancha) && !fin.isAfter(finCancha);
+    }
 }

--- a/src/canchamanager/grupo12/upn/model/Reserva.java
+++ b/src/canchamanager/grupo12/upn/model/Reserva.java
@@ -57,6 +57,23 @@ public class Reserva {
         return pagada;
     }
 
+    // Setters
+    public void setCancha(Cancha cancha) {
+        this.cancha = cancha;
+    }
+
+    public void setFecha(LocalDate fecha) {
+        this.fecha = fecha;
+    }
+
+    public void setHoraInicio(LocalTime horaInicio) {
+        this.horaInicio = horaInicio;
+    }
+
+    public void setHoraFin(LocalTime horaFin) {
+        this.horaFin = horaFin;
+    }
+
     // Setter para el estado de pago
     public void setPagada(boolean pagada) {
         this.pagada = pagada;


### PR DESCRIPTION
## Summary
- validate cancha schedule conflicts before adding a reservation
- allow canceling, editing and marking reservations as paid
- expose setters in `Reserva` for editing

## Testing
- `javac $(find src -name '*.java')`

------
https://chatgpt.com/codex/tasks/task_e_6867ffb98f3083238c6863df6e5a44e9